### PR TITLE
Garage scripts to train and run expert policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,6 @@ dmypy.json
 [Ll]ib
 [Ll]ib64
 [Ll]ocal
-[Ss]cripts
 pyvenv.cfg
 pip-selfcheck.json
 

--- a/scripts/run_expert_policy.py
+++ b/scripts/run_expert_policy.py
@@ -1,0 +1,30 @@
+from garage.experiment import Snapshotter
+import tensorflow as tf
+
+MODEL_PATH = "data/local/experiment/trpo_minigrid/"
+
+def main():
+    snapshotter = Snapshotter()
+    with tf.compat.v1.Session():
+        print("loading model...")
+        data = snapshotter.load(MODEL_PATH)
+        print("model", data)
+        policy = data['algo'].policy
+        env = data['env']
+
+        steps, max_steps = 0, 1500
+        done = False
+        obs = env.reset()  # The initial observation
+        policy.reset()
+
+
+        while steps < max_steps and not done:
+            action = policy.get_action(obs)[0]
+            obs, rew, done, _ = env.step(action)
+            env.render()  # Render the environment to see what's going on (optional)
+            steps += 1
+
+        env.close()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_expert_policy.py
+++ b/scripts/train_expert_policy.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import gym
+from gym_minigrid.wrappers import *
+from garage import wrap_experiment
+from garage.envs import GarageEnv
+from garage.experiment import LocalTFRunner
+from garage.experiment.deterministic import set_seed
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import TRPO
+from garage.tf.policies import CategoricalMLPPolicy
+
+
+@wrap_experiment
+def trpo_minigrid(ctxt=None, seed=1):
+    """Train TRPO with MiniGrid-FourRooms-v0 environment.
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+    """
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
+        env = GarageEnv(env_name='MiniGrid-FourRooms-v0')
+
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    discount=0.99,
+                    max_kl_step=0.01)
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=500, batch_size=4000)
+
+
+trpo_minigrid()


### PR DESCRIPTION
- Introduce scripts to train and run expert policy for four room maze
- Since the dependencies for MAIL and garage have conflict, so please create another virtualenv that installs `garage_requirements.txt` only in order to run the scripts
- run `python scripts/train_expert_policy.py` to train
- run `python scripts/run_expert_policy.py` to demonstrate the policy

P.S. The policy right now seems can't master four room maze. May need to adjust so that it can master it. But I have tried to successfully train a cartpole policy with this script (simply changing the env name will work, but function name `trpo_minigrid` determines the model dir name being saved)
Edit: after training with 500 epochs, the agent is able to find the goal.