### PR TITLE
Improve TRPO training

### DIFF
--- a/scripts/train_expert_policy.py
+++ b/scripts/train_expert_policy.py
@@ -9,6 +9,24 @@ from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 
+from akro.discrete import Discrete
+
+# These wrappers are inspired by https://github.com/maximecb/gym-minigrid/blob/master/gym_minigrid/wrappers.py
+class OnlyPartialObjAndColor(gym.core.ObservationWrapper):
+    def __init__(self, env):
+        super().__init__(env)
+
+        self.observation_space = spaces.Box(
+            low=0,
+            high=255,
+            shape=(7 * 7 * 2,),
+            dtype='uint8'
+        )
+
+    def observation(self, obs):
+        return np.delete(obs["image"], 2, axis=2).flatten()
+
+MAX_STEPS = 19 ** 2 * 2
 
 @wrap_experiment
 def trpo_minigrid(ctxt=None, seed=1):
@@ -21,11 +39,16 @@ def trpo_minigrid(ctxt=None, seed=1):
     """
     set_seed(seed)
     with LocalTFRunner(ctxt) as runner:
-        env = GarageEnv(env_name='MiniGrid-FourRooms-v0')
-
+        env = gym.make("MiniGrid-FourRooms-v0")
+        # The modification of the env has to be made before using wrapper
+        env.action_space = Discrete(3)
+        env.max_steps = MAX_STEPS
+        env = OnlyPartialObjAndColor(env)
+        env = GarageEnv(env)
+        
         policy = CategoricalMLPPolicy(name='policy',
                                       env_spec=env.spec,
-                                      hidden_sizes=(32, 32))
+                                      hidden_sizes=(128, 64, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
@@ -33,10 +56,11 @@ def trpo_minigrid(ctxt=None, seed=1):
                     policy=policy,
                     baseline=baseline,
                     discount=0.99,
-                    max_kl_step=0.01)
+                    max_kl_step=0.001, # 0.001 is better than 0.01
+                    max_path_length=MAX_STEPS,)
 
         runner.setup(algo, env)
-        runner.train(n_epochs=500, batch_size=4000)
+        runner.train(n_epochs=2000, batch_size=4000)
 
 
 trpo_minigrid()


### PR DESCRIPTION
- Introduce WithActionObs and OnlyPartialObjAndColor wrappers
- Change max_kl_step to 0.001
- Change the hidden sizes of the policy
- Set max step for both minigrid and garage

Turns out that even without adding action to the observation, setting `max_kl_step` to 0.001 can already train a TRPO agent with average return more than 0.9.